### PR TITLE
Fix X-Apollo-Tracing No Schema Issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ These are the settings currently available:
   'schema.polling.interval': 2000, // schema polling interval in ms
   'schema.disableComments': boolean,
   'tracing.hideTracingResponse': true,
-  'tracing.tracingSupported': true, // set false to disable tracing, x-apollo-tracing header
+  'tracing.tracingSupported': true, // set false to remove x-apollo-tracing header from Schema fetch requests
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ These are the settings currently available:
   'schema.polling.interval': 2000, // schema polling interval in ms
   'schema.disableComments': boolean,
   'tracing.hideTracingResponse': true,
+  'tracing.tracingSupported': true, // set false to disable tracing, x-apollo-tracing header
 }
 ```
 
@@ -108,6 +109,7 @@ interface ISettings {
   'schema.polling.interval': number
   'schema.disableComments': boolean
   'tracing.hideTracingResponse': boolean
+  'tracing.tracingSupported': boolean
 }
 ```
 

--- a/packages/graphql-playground-html/src/render-playground-page.ts
+++ b/packages/graphql-playground-html/src/render-playground-page.ts
@@ -21,6 +21,7 @@ export interface ISettings {
   'editor.theme': Theme
   'editor.reuseHeaders': boolean
   'tracing.hideTracingResponse': boolean
+  'tracing.tracingSupported': boolean
   'editor.fontSize': number
   'editor.fontFamily': string
   'request.credentials': string

--- a/packages/graphql-playground-react/src/components/Playground.tsx
+++ b/packages/graphql-playground-react/src/components/Playground.tsx
@@ -260,6 +260,9 @@ export class Playground extends React.PureComponent<Props & ReduxProps, State> {
             ? props.sessionHeaders
             : JSON.stringify(props.headers),
         credentials: props.settings['request.credentials'],
+        useTracingHeader:
+          !this.initialSchemaFetch &&
+          this.props.settings['tracing.tracingSupported'],
       }
       const schema = await schemaFetcher.fetch(data)
       schemaFetcher.subscribe(data, newSchema => {

--- a/packages/graphql-playground-react/src/components/Playground/SchemaFetcher.ts
+++ b/packages/graphql-playground-react/src/components/Playground/SchemaFetcher.ts
@@ -15,6 +15,7 @@ export interface TracingSchemaTuple {
 export interface SchemaFetchProps {
   endpoint: string
   headers?: string
+  useTracingHeader?: boolean
 }
 
 export type LinkGetter = (session: LinkCreatorProps) => { link: ApolloLink }
@@ -105,10 +106,14 @@ export class SchemaFetcher {
   ): Promise<{ schema: GraphQLSchema; tracingSupported: boolean } | null> {
     const hash = this.hash(session)
     const { endpoint } = session
-    const headers = {
+    const headersTracing = {
       ...parseHeaders(session.headers),
       'X-Apollo-Tracing': '1',
     }
+    const headersNoTracing = {
+      ...parseHeaders(session.headers),
+    }
+    const headers = session.useTracingHeader ? headersTracing : headersNoTracing
 
     const options = set(session, 'headers', headers) as any
 

--- a/packages/graphql-playground-react/src/state/workspace/reducers.ts
+++ b/packages/graphql-playground-react/src/state/workspace/reducers.ts
@@ -56,6 +56,7 @@ export const defaultSettings: ISettings = {
   'schema.polling.endpointFilter': '*localhost*',
   'schema.polling.interval': 2000,
   'tracing.hideTracingResponse': true,
+  'tracing.tracingSupported': true,
 }
 
 // tslint:disable-next-line:max-classes-per-file

--- a/packages/graphql-playground-react/src/types.ts
+++ b/packages/graphql-playground-react/src/types.ts
@@ -32,4 +32,5 @@ export interface ISettings {
   ['schema.polling.endpointFilter']: string
   ['schema.polling.interval']: number
   ['tracing.hideTracingResponse']: boolean
+  ['tracing.tracingSupported']: boolean
 }


### PR DESCRIPTION
Fixes #409.

Changes proposed in this pull request:
- Add  `tracing.tracingSupported` setting that when false remove `x-apollo-tracing` header from schemaFetch requests
- Don't send `x-apollo-tracing` header if `initialSchemaFetch ` is `true`